### PR TITLE
src/forecasting/baseline.py NaiveMovingAverage - magic number 5 replaced with self.window

### DIFF
--- a/src/forecasting/baselines.py
+++ b/src/forecasting/baselines.py
@@ -21,7 +21,7 @@ class NaiveMovingAverage(LocalForecastingModel):
         super().fit(series)
         self._history = series.data_array().to_series().values
         self._fitted_values = (
-            series.data_array().to_series().rolling(window=5).mean().bfill()
+            series.data_array().to_series().rolling(window=self.window).mean().bfill()
         )
 
     def predict(self, n: int, num_samples: int = 1):


### PR DESCRIPTION
Although it's not used in the predict, it seems that `self._fitted_values` was always using a window size of `5` rather than a user specified one. Really minor change that stood out to me while reading the code.  